### PR TITLE
Adding can_utils wrapper for the python-can library

### DIFF
--- a/CAN/CAN_config.json
+++ b/CAN/CAN_config.json
@@ -14,11 +14,11 @@
   "sensor_packets": {
     "SENSOR_PKT_0": {
       "sensors": {
-        "sensor 1": {
+        "sensor1": {
           "start_bit": 20,
           "length": 12
         },
-        "sensor 2": {
+        "sensor2": {
           "start_bit": 0,
           "length": 20
         }
@@ -27,11 +27,11 @@
     },
     "SENSOR_PKT_1": {
       "sensors": {
-        "sensor 3": {
+        "sensor3": {
           "start_bit": 45,
           "length": 12
         },
-        "sensor 4": {
+        "sensor4": {
           "start_bit": 45,
           "length": 19
         }

--- a/CAN/CAN_config.json
+++ b/CAN/CAN_config.json
@@ -1,0 +1,42 @@
+{
+  "computers": {
+    "jetson": [
+
+    ],
+    "rpi0": [
+      "SENSOR_PKT_0",
+      "SENSOR_PKT_1"
+    ],
+    "rpi1": [
+
+    ]
+  },
+  "sensor_packets": {
+    "SENSOR_PKT_0": {
+      "sensors": {
+        "sensor 1": {
+          "start_bit": 20,
+          "length": 12
+        },
+        "sensor 2": {
+          "start_bit": 0,
+          "length": 20
+        }
+      },
+      "size_of_packet": 32
+    },
+    "SENSOR_PKT_1": {
+      "sensors": {
+        "sensor 3": {
+          "start_bit": 45,
+          "length": 12
+        },
+        "sensor 4": {
+          "start_bit": 45,
+          "length": 19
+        }
+      },
+      "size_of_packet": 64
+    }
+  }
+}

--- a/CAN/README.md
+++ b/CAN/README.md
@@ -80,11 +80,11 @@ The max size is 64 bits I'm decently sure.
   "sensor_packets": {
     "SENSOR_PKT_0": {
       "sensors": { // sensors that are in the packet
-        "sensor 1": {
+        "sensor1": {
           "start_bit": 20, // where to start the bits of this sensor with lsb being bit 0
           "length": 12 // how many bits to dedicate to this sensor value
         },
-        "sensor 2": {
+        "sensor2": {
           "start_bit": 0,
           "length": 20
         }

--- a/CAN/README.md
+++ b/CAN/README.md
@@ -1,0 +1,120 @@
+# CAN Stuff
+
+## References
+[Can Frame](https://embedclogic.com/can-protocol/standard-can-vs-extended-can-protocol-frame/) - how the bits are
+ organized in the frame
+
+[Cubemars python library](https://pypi.org/project/TMotorCANControl/) - for controlling the motor
+
+[General python CAN library](https://python-can.readthedocs.io/en/stable/index.html) - for all other data
+
+[Setup + code for specific CAN rpi hat we are using](https://www.waveshare.com/wiki/RS485_CAN_HAT)
+
+## Using `can_utils`
+
+### Setup
+Make sure to run the command
+```bash
+python3 -m pip install -r requirements.txt
+```
+
+### Arbitration IDs
+These are the ids that set the priority for CAN packets. Each sensor packet, motor, and computer has one of these.
+
+*Note: we might not need the computer ones at all - we'll figure that out as we decide sensor readings (hopefully soon)*
+
+#### Usage
+
+```python
+from CAN.can_utils import ARBITRATION_ID
+
+# reference type of arbitration id (type ARBITRATION_ID)
+ARBITRATION_ID.SENSOR_PKT_0 # = ARBITRATION_ID.SENSOR_PKT_0
+
+# reference value of arbitration id (int)
+ARBITRATION_ID.SENSOR_PKT_0.value # = 4
+```
+
+### Storing/Reading bits
+
+Consider a 16 bit data section
+
+| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+
+If we want to dedicate the first byte to sensor **k** and the second byte to sensor **j**.
+
+Let **k** = `247` or `11110111` in binary, and **j** = `132` or `10000100` in binary.
+When we set the first byte to **k** and the second byte to **j** we get:
+
+| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | <- **j** | **k** -> | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 |
+|---|---|---|---|---|---|---|---|----------|----------|---|----|----|----|---|----|----|---|
+| 1 | 0 | 0 | 0 | 0 | 1 | 0 | 0 |          |          | 1 | 1  | 1  | 1  | 0 | 1  | 1  | 1 |
+
+Which will then be represented as `1000010011110111` in binary. The next step is to convert it to a bytestring that can be used by the  `python-can` library.
+calling `can_pkt.get_bytearray(<Arbitration id for packet>, <bits to convert>)` will accomplish this. There are a few reasons why we use this instead of just calling `bytestring(bits)` so if you're interested just reach out to me.
+
+It will not always be as clean as 8 bits per number (that's why this library exists lol) but the total number of bits will always have to be a multiple of 8 since that is how data is explained in CAN protocol (DLC bits).
+The max size is 64 bits I'm decently sure.
+
+### Configuration
+
+```json
+{
+  // this section configures what sensor packets need to be loaded for what computers
+  // I'm still deciding how I will add implementation of motor stuff here
+  "computers": {
+    "jetson": [
+
+    ],
+    "rpi0": [
+      "SENSOR_PKT_0"
+    ],
+    "rpi1": [
+
+    ]
+  },
+  // the sets of sensors that we want to send in one packet - add more with the same style
+  // we can change the name of these at some point
+  "sensor_packets": {
+    "SENSOR_PKT_0": {
+      "sensors": { // sensors that are in the packet
+        "sensor 1": {
+          "start_bit": 20, // where to start the bits of this sensor with lsb being bit 0
+          "length": 12 // how many bits to dedicate to this sensor value
+        },
+        "sensor 2": {
+          "start_bit": 0,
+          "length": 20
+        }
+      },
+      "size_of_packet": 32 // total size of packet
+    }
+  }
+}
+```
+
+### Example
+
+```python
+import can # not used here but you will need to import it at some point
+from CAN.can_utils import ARBITRATION_ID, Computer
+
+# initialization of this computer
+can_pkt = Computer("rpi0")
+
+# Sending
+bits = 0
+bits = can_pkt.populate_bits(ARBITRATION_ID.SENSOR_PKT_0, "sensor 1", bits, 3491)
+bits = can_pkt.populate_bits(ARBITRATION_ID.SENSOR_PKT_0, "sensor 2", bits, 25592)
+
+message = can_pkt.get_bytearray(ARBITRATION_ID.SENSOR_PKT_0, bits)
+# send data with can bus (read docs)
+
+# Receiving
+# read incoming bytestring from message (read docs)
+incoming_bits = int.from_bytes(message, "big")
+sensor1_reading = can_pkt.read_bits(ARBITRATION_ID.SENSOR_PKT_0, "sensor 1", incoming_bits) # 3491
+sensor2_reading = can_pkt.read_bits(ARBITRATION_ID.SENSOR_PKT_0, "sensor 2", incoming_bits) # 25592
+```

--- a/CAN/can_utils.py
+++ b/CAN/can_utils.py
@@ -11,6 +11,10 @@ import math
 from typing import List, Dict
 import json
 
+from can import Message
+
+from CAN.test_server import can_pkt
+
 """
 These are the arbitration ids for determining what CAN packet has what data
 and establishes the priorities of each packet
@@ -72,7 +76,8 @@ class Sensor_Packet():
     sensors: Dict[str, Sensor]
     size: int
 
-
+# get arb id should also use value
+# function to get data just given message
 class Computer():
     def __init__(self, computer_id: str):
         self.computer_id = computer_id
@@ -132,3 +137,22 @@ class Computer():
             bits = bits >> 8
 
         return bytearray(bytes_in_bits)
+
+    def get_filters(self) -> List[Dict[str, int]]:
+        return [{"can_id": i, "extended": False} for i in self.sensor_packets.keys()]
+
+    def process_message(self, message: Message) -> Dict:
+        arbitration_id: ARBITRATION_ID = ARBITRATION_ID(message.arbitration_id)
+
+        recv_data: int = int.from_bytes(message.data, byteorder="big")
+        return_data = {"arbitration_id": arbitration_id, "sensors": {}}
+
+        for sensor in self.sensor_packets[arbitration_id.value].sensors.keys():
+            return_data["sensors"][sensor] = self.read_bits(arbitration_id, sensor, recv_data)
+
+        return return_data
+
+
+# rtr bit stuff
+
+    

--- a/CAN/can_utils.py
+++ b/CAN/can_utils.py
@@ -117,7 +117,7 @@ class Computer():
 
         return sensor.get_data_from_bits(bits)
 
-    def get_length(self, AF_id: ARBITRATION_ID):
+    def get_length(self, AF_id: ARBITRATION_ID) -> int:
         pkt = self.sensor_packets.get(AF_id.value)
         if pkt is None:
             raise KeyError(f"The config for this computer doesn't contain arbitration id: {AF_id}")
@@ -139,7 +139,13 @@ class Computer():
     def get_filters(self) -> List[Dict[str, int]]:
         return [{"can_id": i, "can_mask": 0x7FF, "extended": False} for i in self.sensor_packets.keys()]
 
-    def send_message(self, can_bus: can.interface.Bus, AF_id: ARBITRATION_ID, **kwargs):
+    """
+    params:
+    - the declared can.interface.Bus object
+    - arbitration id for the packet you want to send
+    - the sensors for the packet you want to send
+    """
+    def send_message(self, can_bus: can.interface.Bus, AF_id: ARBITRATION_ID, **kwargs) -> None:
         bits = 0
         for name, value in kwargs.items():
             sensor = self.sensor_packets[AF_id.value].sensors.get(name)
@@ -150,7 +156,7 @@ class Computer():
 
         can_bus.send(can.Message(arbitration_id=AF_id.value, data=self.get_bytearray(AF_id, bits)))
 
-    def process_message(self, message: can.Message) -> Dict:
+    def process_message(self, message: can.Message) -> None:
         arbitration_id: ARBITRATION_ID = ARBITRATION_ID(message.arbitration_id)
 
         recv_data: int = int.from_bytes(message.data, byteorder="big")

--- a/CAN/can_utils.py
+++ b/CAN/can_utils.py
@@ -1,0 +1,65 @@
+# work in progress
+
+"""
+Tools that help organize how the rover, and it's different computers/motors
+treat communicating with each other through CAN
+"""
+
+from enum import Enum
+from dataclasses import dataclass
+
+"""
+These are the arbitration ids for determining what CAN packet has what data
+and establishes the priorities of each packet
+"""
+class ARBITRATION_IDS(Enum):
+    # for jetson computer general comms (may not be used)
+    JETSON = 1
+
+    # for raspberry pi general comms (may not be used)
+    RPI_0 = 2
+    RPI_1 = 3
+
+    # for sensor data (could represent multiple sensors)
+    # may not need this many
+    SENSOR_PKT_0 = 4
+    SENSOR_PKT_1 = 5
+    SENSOR_PKT_2 = 6
+    SENSOR_PKT_3 = 7
+
+    # movement motors on the rover
+    ROVER_MOTOR_0 = 8
+    ROVER_MOTOR_1 = 9
+    ROVER_MOTOR_2 = 10
+    ROVER_MOTOR_3 = 11
+    ROVER_MOTOR_4 = 12
+    ROVER_MOTOR_5 = 13
+
+    # motors that move the arm
+    ARM_MOTOR_0 = 14
+    ARM_MOTOR_1 = 15
+    ARM_MOTOR_2 = 16
+    ARM_MOTOR_3 = 17
+    ARM_MOTOR_4 = 18
+
+
+# defines some value in the data bits
+@dataclass
+class FormatItem:
+    id: str
+    start_bit: int
+    length: int
+    parsed_data: int = None
+
+    # gets data based on bits the item exists in
+    def get_data_from_bits(self, bits: int) -> int:
+        #
+        self.parsed_data = (bits >> self.start_bit) & int("1" * self.length, base=2)
+        return self.parsed_data
+
+# do we want to include a function that simplifies the can library or is this nearly enough?
+
+if __name__ == "__main__":
+    # some testing stuff, will be removed
+    item = FormatItem("some value", 10, 10)
+    print(item.get_data_from_bits(0b0010011001001001))

--- a/CAN/test_client.py
+++ b/CAN/test_client.py
@@ -3,7 +3,7 @@ import time
 import can
 
 can_pkt = Computer("rpi0")
-bus = can.interface.Bus('can0', interface='socketcan', bitrate=1000000, can_filters=can_pkt.get_filters())
+bus = can.interface.Bus('can0', interface='socketcan', bitrate=1000000, filters=can_pkt.get_filters())
 can.Notifier(bus, [can_pkt.process_message])
 
 while True:

--- a/CAN/test_client.py
+++ b/CAN/test_client.py
@@ -1,14 +1,10 @@
-from CAN.can_utils import Computer, ARBITRATION_ID
+from can_utils import Computer
 import time
 import can
 
 can_pkt = Computer("rpi0")
-bus = can.interface.Bus(channel='socketcan', interface='can0', bitrate=1000000, can_filters=can_pkt.get_filters())
+bus = can.interface.Bus('can0', interface='socketcan', bitrate=1000000, can_filters=can_pkt.get_filters())
+can.Notifier(bus, [can_pkt.process_message])
 
 while True:
-    msg = bus.recv()
-
-    d = can_pkt.process_message(msg)
-    print(d)
-
     time.sleep(1)

--- a/CAN/test_client.py
+++ b/CAN/test_client.py
@@ -1,0 +1,14 @@
+from CAN.can_utils import Computer, ARBITRATION_ID
+import time
+import can
+
+can_pkt = Computer("rpi0")
+bus = can.interface.Bus(channel='socketcan', interface='can0', bitrate=1000000, can_filters=can_pkt.get_filters())
+
+while True:
+    msg = bus.recv()
+
+    d = can_pkt.process_message(msg)
+    print(d)
+
+    time.sleep(1)

--- a/CAN/test_server.py
+++ b/CAN/test_server.py
@@ -1,0 +1,17 @@
+from CAN.can_utils import Computer, ARBITRATION_ID
+import time
+import can
+import random
+
+can_pkt = Computer("rpi0")
+bus = can.interface.Bus(channel='socketcan', interface='can0', bitrate=1000000, can_filters=can_pkt.get_filters())
+
+while True:
+    bits = 0
+    can_pkt.populate_bits(ARBITRATION_ID.SENSOR_PKT_0, "sensor 1", bits, random.randint(0, 4096))
+    can_pkt.populate_bits(ARBITRATION_ID.SENSOR_PKT_0, "sensor 2", bits, random.randint(0, 1048576))
+    msg = can.Message(arbitration_id=can_pkt.sensor_packets[0].arbitration_id.value,
+                      data=can_pkt.get_bytearray(ARBITRATION_ID.SENSOR_PKT_0, bits), is_extended_id=False)
+
+    bus.send(msg)
+    time.sleep(1)

--- a/CAN/test_server.py
+++ b/CAN/test_server.py
@@ -1,17 +1,11 @@
-from CAN.can_utils import Computer, ARBITRATION_ID
+from can_utils import Computer, ARBITRATION_ID
 import time
 import can
 import random
 
 can_pkt = Computer("rpi0")
-bus = can.interface.Bus(channel='socketcan', interface='can0', bitrate=1000000, can_filters=can_pkt.get_filters())
+bus = can.interface.Bus('can0', interface='socketcan', bitrate=1000000, filters=can_pkt.get_filters())
 
 while True:
-    bits = 0
-    can_pkt.populate_bits(ARBITRATION_ID.SENSOR_PKT_0, "sensor 1", bits, random.randint(0, 4096))
-    can_pkt.populate_bits(ARBITRATION_ID.SENSOR_PKT_0, "sensor 2", bits, random.randint(0, 1048576))
-    msg = can.Message(arbitration_id=can_pkt.sensor_packets[0].arbitration_id.value,
-                      data=can_pkt.get_bytearray(ARBITRATION_ID.SENSOR_PKT_0, bits), is_extended_id=False)
-
-    bus.send(msg)
+    can_pkt.send_message(bus, ARBITRATION_ID.SENSOR_PKT_0, sensor1=random.randint(0, 4096), sensor2=random.randint(0, 1048576))
     time.sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-can==4.4.2
+TMotorCANControl==1.2.6


### PR DESCRIPTION
Simplifies sending and receiving CAN packets.

The config isn't done, but everything should be ready for basic sensor data.